### PR TITLE
chore: changed default port and updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Data Federation console works as a remote bundle for OCP console. To run Data Fe
 Follow these steps to run OCP console in development mode:
 
 1. Follow everything as mentioned in the console [README.md](https://github.com/openshift/console) to build the application.
-2. Run the console bridge as follows `./bin/bridge -plugins dfr-console=http://localhost:9001/`
-3. Run developemnt mode of console by going into `console/frontend` and running `yarn run dev`
+2. Run the console bridge as follows:
+    a. `./bin/bridge -plugins dfr-console=http://localhost:9002/` (if you wish to run data federation only)
+    b. `./bin/bridge -plugins odf-console=http://localhost:9001/ -plugins dfr-console=http://localhost:9002/` (in case you have a running instance of odf)
+3. Run development mode of console by going into `console/frontend` and running `yarn run dev`
 
 After the OCP console is set as required by Data Federation console. Performs the following steps to make it run locally:
 
 1. Clone this repo.
 2. Pull all required dependencies by running `yarn install`.
 3. `yarn build` to build the plugin, generating output to `dist` directory.
-4. `yarn http-server` to start an HTTP server hosting the generated assets, or, run the development mode of dfr-console using `yarn run dev`. This runs a webserver in port 9001.
+4. `yarn http-server` to start an HTTP server hosting the generated assets, or, run the development mode of dfr-console using `yarn run dev`. This runs a webserver in port 9002.

--- a/http-server.sh
+++ b/http-server.sh
@@ -6,4 +6,4 @@ PUBLIC_PATH="$1"
 shift
 SERVER_OPTS="$@"
 
-./node_modules/.bin/http-server $PUBLIC_PATH -p 9001 -c-1 --cors $SERVER_OPTS
+./node_modules/.bin/http-server $PUBLIC_PATH -p 9002 -c-1 --cors $SERVER_OPTS

--- a/oc-manifest.yaml
+++ b/oc-manifest.yaml
@@ -28,7 +28,7 @@ spec:
         - name: dfr-console
           image: quay.io/vszocs/dfr-console
           ports:
-            - containerPort: 9001
+            - containerPort: 9002
               protocol: TCP
           imagePullPolicy: Always
           args:
@@ -66,10 +66,10 @@ metadata:
     app.kubernetes.io/part-of: dfr-console
 spec:
   ports:
-    - name: 9001-tcp
+    - name: 9002-tcp
       protocol: TCP
-      port: 9001
-      targetPort: 9001
+      port: 9002
+      targetPort: 9002
   selector:
     app: dfr-console
   type: ClusterIP
@@ -84,5 +84,5 @@ spec:
   service:
     name: dfr-console
     namespace: dfr-console
-    port: 9001
+    port: 9002
     basePath: '/'

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,7 +18,7 @@ const config: webpack.Configuration = {
   },
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
-    port: 9001,
+    port: 9002,
     writeToDisk: true,
   },
   resolve: {


### PR DESCRIPTION
updated the default port to 9002 so that we can run both ODF and DF parallelly.
also updated the readme.md with the command to bridge in case we need to bridge both the console.